### PR TITLE
Recover from timeouts

### DIFF
--- a/tests/simple/check.go
+++ b/tests/simple/check.go
@@ -1,0 +1,24 @@
+package simple
+
+import "fmt"
+
+// isDocumentEqualTo reads an existing document and checks that it is equal to the given document.
+// Returns: (isEqual,currentRevision,error)
+func (t *simpleTest) isDocumentEqualTo(c *collection, key string, expected UserDocument) (bool, string, error) {
+	operationTimeout, retryTimeout := t.OperationTimeout, t.RetryTimeout
+	var result UserDocument
+	t.log.Infof("Checking existing document '%s' from '%s'...", key, c.name)
+	resp, err := t.client.Get(fmt.Sprintf("/_api/document/%s/%s", c.name, key), nil, nil, &result, []int{200, 201, 202}, []int{400, 404, 307}, operationTimeout, retryTimeout)
+	if err != nil {
+		// This is a failure
+		t.log.Errorf("Failed to read document '%s' from '%s': %v", key, c.name, err)
+		return false, "", maskAny(err)
+	}
+	// Compare document against expected document
+	if result.Equals(expected) {
+		// Found an exact match
+		return true, resp.Rev, nil
+	}
+	t.log.Infof("Document '%s' in '%s'  returned different values: got %q expected %q", key, c.name, result, expected)
+	return false, resp.Rev, nil
+}

--- a/tests/simple/simple.go
+++ b/tests/simple/simple.go
@@ -217,6 +217,13 @@ type UserDocument struct {
 	Odd   bool   `json:"odd"`
 }
 
+// Equals returns true when the value fields of `d` and `other` are the equal.
+func (d UserDocument) Equals(other UserDocument) bool {
+	return d.Value == other.Value &&
+		d.Name == other.Name &&
+		d.Odd == other.Odd
+}
+
 func (t *simpleTest) reportFailure(f test.Failure) {
 	t.failures++
 	t.listener.ReportFailure(f)
@@ -571,16 +578,17 @@ func createTestPlan(steps int) []int {
 // createRandomIfMatchHeader creates a request header with one of the following (randomly chosen):
 // 1: with an `If-Match` entry for the given revision.
 // 2: without an `If-Match` entry for the given revision.
-func createRandomIfMatchHeader(hdr map[string]string, rev string) (map[string]string, string) {
+// The bool response is true when an `If-Match` has been added, false otherwise.
+func createRandomIfMatchHeader(hdr map[string]string, rev string) (map[string]string, string, bool) {
 	if rev == "" {
-		return hdr, "without If-Match"
+		return hdr, "without If-Match", false
 	}
 	switch rand.Intn(2) {
 	case 0:
 		hdr = ifMatchHeader(hdr, rev)
-		return hdr, "with If-Match"
+		return hdr, "with If-Match", true
 	default:
-		return hdr, "without If-Match"
+		return hdr, "without If-Match", false
 	}
 }
 

--- a/tests/simple/simple_read.go
+++ b/tests/simple/simple_read.go
@@ -11,7 +11,7 @@ import (
 func (t *simpleTest) readExistingDocument(c *collection, key, rev string, updateRevision, skipExpectedValueCheck bool) (string, error) {
 	operationTimeout, retryTimeout := t.OperationTimeout, t.RetryTimeout
 	var result UserDocument
-	hdr, ifMatchStatus := createRandomIfMatchHeader(nil, rev)
+	hdr, ifMatchStatus, _ := createRandomIfMatchHeader(nil, rev)
 	t.log.Infof("Reading existing document '%s' (%s) from '%s'...", key, ifMatchStatus, c.name)
 	if _, err := t.client.Get(fmt.Sprintf("/_api/document/%s/%s", c.name, key), nil, hdr, &result, []int{200, 201, 202}, []int{400, 404, 307}, operationTimeout, retryTimeout); err != nil {
 		// This is a failure

--- a/tests/simple/simple_remove.go
+++ b/tests/simple/simple_remove.go
@@ -13,13 +13,24 @@ func (t *simpleTest) removeExistingDocument(collectionName string, key, rev stri
 	operationTimeout, retryTimeout := t.OperationTimeout, t.RetryTimeout
 	q := url.Values{}
 	q.Set("waitForSync", "true")
-	hdr, ifMatchStatus := createRandomIfMatchHeader(nil, rev)
+	hdr, ifMatchStatus, _ := createRandomIfMatchHeader(nil, rev)
 	t.log.Infof("Removing existing document '%s' (%s) from '%s'...", key, ifMatchStatus, collectionName)
-	if _, err := t.client.Delete(fmt.Sprintf("/_api/document/%s/%s", collectionName, key), q, hdr, []int{200, 201, 202}, []int{400, 404, 412, 307}, operationTimeout, retryTimeout); err != nil {
+	resp, err := t.client.Delete(fmt.Sprintf("/_api/document/%s/%s", collectionName, key), q, hdr, []int{200, 201, 202, 404}, []int{400, 412, 307}, operationTimeout, retryTimeout)
+	if err != nil {
 		// This is a failure
 		t.deleteExistingCounter.failed++
 		t.reportFailure(test.NewFailure("Failed to delete existing document '%s' (%s) in collection '%s': %v", key, ifMatchStatus, collectionName, err))
 		return maskAny(err)
+	} else if resp.StatusCode == 404 {
+		// Document not found.
+		// This can happen if the first attempt timed out, but did actually succeed.
+		// So we accept this is there are multiple attempts.
+		if resp.Attempts <= 1 {
+			// Not enough attempts, this is a failure
+			t.deleteExistingCounter.failed++
+			t.reportFailure(test.NewFailure("Failed to delete existing document '%s' (%s) in collection '%s': got 404 after only 1 attempt", key, ifMatchStatus, collectionName))
+			return maskAny(fmt.Errorf("Failed to delete existing document '%s' (%s) in collection '%s': got 404 after only 1 attempt", key, ifMatchStatus, collectionName))
+		}
 	}
 	t.deleteExistingCounter.succeeded++
 	t.log.Infof("Removing existing document '%s' (%s) from '%s' succeeded", key, ifMatchStatus, collectionName)

--- a/tests/simple/simple_replace.go
+++ b/tests/simple/simple_replace.go
@@ -16,7 +16,7 @@ func (t *simpleTest) replaceExistingDocument(c *collection, key, rev string) (st
 	q := url.Values{}
 	q.Set("waitForSync", "true")
 	newName := fmt.Sprintf("Updated name %s", time.Now())
-	hdr, ifMatchStatus := createRandomIfMatchHeader(nil, rev)
+	hdr, ifMatchStatus, explicitRev := createRandomIfMatchHeader(nil, rev)
 	t.log.Infof("Replacing existing document '%s' (%s) in '%s' (name -> '%s')...", key, ifMatchStatus, c.name, newName)
 	newDoc := UserDocument{
 		Key:   key,
@@ -24,12 +24,39 @@ func (t *simpleTest) replaceExistingDocument(c *collection, key, rev string) (st
 		Value: rand.Int(),
 		Odd:   rand.Int()%2 == 0,
 	}
-	update, err := t.client.Put(fmt.Sprintf("/_api/document/%s/%s", c.name, key), q, hdr, newDoc, "", nil, []int{200, 201, 202}, []int{400, 404, 412, 307}, operationTimeout, retryTimeout)
+	update, err := t.client.Put(fmt.Sprintf("/_api/document/%s/%s", c.name, key), q, hdr, newDoc, "", nil, []int{200, 201, 202, 412}, []int{400, 404, 307}, operationTimeout, retryTimeout)
 	if err != nil {
 		// This is a failure
 		t.replaceExistingCounter.failed++
 		t.reportFailure(test.NewFailure("Failed to replace existing document '%s' (%s) in collection '%s': %v", key, ifMatchStatus, c.name, err))
 		return "", maskAny(err)
+	} else if update.StatusCode == 412 {
+		if explicitRev {
+			// Expected revision did NOT match.
+			// This may happen when a coordinator succeeds in the first attempt but we've already timed out.
+			// Check document against what we expect after the replace.
+			expected := c.existingDocs[key]
+			expected.Name = newName
+			if match, rev, err := t.isDocumentEqualTo(c, key, expected); err != nil {
+				// Failed to read document. This is a failure.
+				t.replaceExistingCounter.failed++
+				t.reportFailure(test.NewFailure("Failed to read existing document '%s' (%s) in collection '%s' that should have been replaced: %v", key, ifMatchStatus, c.name, err))
+				return "", maskAny(err)
+			} else if !match {
+				// The document does not match what we expect after the replace. This is a failure.
+				t.replaceExistingCounter.failed++
+				t.reportFailure(test.NewFailure("Failed to replace existing document '%s' (%s) in collection '%s': got 412 but has not been replaced", key, ifMatchStatus, c.name))
+				return "", maskAny(fmt.Errorf("Failed to replace existing document '%s' (%s) in collection '%s': got 412 but has not been replaced", key, ifMatchStatus, c.name))
+			} else {
+				// Match found, document has been replaced after all
+				update.Rev = rev
+			}
+		} else {
+			// We got a 412 without asking for an explicit revision. This is a failure.
+			t.replaceExistingCounter.failed++
+			t.reportFailure(test.NewFailure("Failed to replace existing document '%s' (%s) in collection '%s': got 412 but did not set If-Match", key, ifMatchStatus, c.name))
+			return "", maskAny(fmt.Errorf("Failed to replace existing document '%s' (%s) in collection '%s': got 412 but did not set If-Match", key, ifMatchStatus, c.name))
+		}
 	}
 	// Update internal doc
 	newDoc.rev = update.Rev

--- a/tests/simple/simple_replace.go
+++ b/tests/simple/simple_replace.go
@@ -35,8 +35,7 @@ func (t *simpleTest) replaceExistingDocument(c *collection, key, rev string) (st
 			// Expected revision did NOT match.
 			// This may happen when a coordinator succeeds in the first attempt but we've already timed out.
 			// Check document against what we expect after the replace.
-			expected := c.existingDocs[key]
-			expected.Name = newName
+			expected := newDoc
 			if match, rev, err := t.isDocumentEqualTo(c, key, expected); err != nil {
 				// Failed to read document. This is a failure.
 				t.replaceExistingCounter.failed++

--- a/tests/util/arango_client.go
+++ b/tests/util/arango_client.go
@@ -43,9 +43,10 @@ type ArangoError struct {
 }
 
 type ArangoResponse struct {
-	StatusCode     int
-	CoordinatorURL string
-	Rev            string
+	StatusCode     int    // HTTP status code of last attempt
+	CoordinatorURL string // URL of coordinator used for last attempt
+	Rev            string // Revision of document as returned by database (not set for all operations)
+	Attempts       int    // Number of attempts
 }
 
 func (e ArangoError) Error() string {
@@ -146,15 +147,14 @@ func (c *ArangoClient) requestWithRetry(method, urlPath string, query url.Values
 	if err != nil {
 		return ArangoResponse{}, maskAny(err)
 	}
-	attempt := 0
 	var aresp ArangoResponse
 	op := func() error {
-		attempt++
+		aresp.Attempts++
 		start := time.Now()
 		client := createClient(operationTimeout)
 		url, lastCoordinatorURL, err := c.createURL(urlPath, query)
 		if err != nil {
-			return maskAny(errors.Wrapf(err, "Failed creating URL for path '%s' (attempt %d, started at %s, after %s, error %v)", urlPath, attempt, start.Format(startTSFormat), time.Since(start), err))
+			return maskAny(errors.Wrapf(err, "Failed creating URL for path '%s' (attempt %d, started at %s, after %s, error %v)", urlPath, aresp.Attempts, start.Format(startTSFormat), time.Since(start), err))
 		}
 		aresp.CoordinatorURL = lastCoordinatorURL.String()
 		var rd io.Reader
@@ -163,7 +163,7 @@ func (c *ArangoClient) requestWithRetry(method, urlPath string, query url.Values
 		}
 		req, err := http.NewRequest(method, url, rd)
 		if err != nil {
-			return maskAny(errors.Wrapf(err, "Failed creating %s request for path '%s' (attempt %d, started at %s, after %s, error %v)", method, urlPath, attempt, start.Format(startTSFormat), time.Since(start), err))
+			return maskAny(errors.Wrapf(err, "Failed creating %s request for path '%s' (attempt %d, started at %s, after %s, error %v)", method, urlPath, aresp.Attempts, start.Format(startTSFormat), time.Since(start), err))
 		}
 		if inputData != nil {
 			req.Header.Set("Content-Type", contentType)
@@ -174,10 +174,10 @@ func (c *ArangoClient) requestWithRetry(method, urlPath string, query url.Values
 		resp, err := client.Do(req)
 		if err != nil {
 			c.lastCoordinatorURL = nil // Change coordinator
-			return maskAny(errors.Wrapf(err, "Failed performing %s request to %s (attempt %d, started at %s, after %s, error %v)", method, url, attempt, start.Format(startTSFormat), time.Since(start), err))
+			return maskAny(errors.Wrapf(err, "Failed performing %s request to %s (attempt %d, started at %s, after %s, error %v)", method, url, aresp.Attempts, start.Format(startTSFormat), time.Since(start), err))
 		}
 		// Process response
-		if err := c.handleResponse(resp, method, url, result, &aresp, successStatusCodes, failureStatusCodes, attempt, start); err != nil {
+		if err := c.handleResponse(resp, method, url, result, &aresp, successStatusCodes, failureStatusCodes, start); err != nil {
 			return maskAny(err)
 		}
 		return nil
@@ -189,7 +189,7 @@ func (c *ArangoClient) requestWithRetry(method, urlPath string, query url.Values
 	return aresp, nil
 }
 
-func (c *ArangoClient) handleResponse(resp *http.Response, method, url string, result interface{}, aresp *ArangoResponse, successStatusCodes, failureStatusCodes []int, attempt int, start time.Time) error {
+func (c *ArangoClient) handleResponse(resp *http.Response, method, url string, result interface{}, aresp *ArangoResponse, successStatusCodes, failureStatusCodes []int, start time.Time) error {
 	// Store status code
 	aresp.StatusCode = resp.StatusCode
 
@@ -197,7 +197,7 @@ func (c *ArangoClient) handleResponse(resp *http.Response, method, url string, r
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return maskAny(errors.Wrapf(err, "Failed reading response data from %s request to %s (attempt %d, started at %s, after %s, error %v)", method, url, attempt, start.Format(startTSFormat), time.Since(start), err))
+		return maskAny(errors.Wrapf(err, "Failed reading response data from %s request to %s (attempt %d, started at %s, after %s, error %v)", method, url, aresp.Attempts, start.Format(startTSFormat), time.Since(start), err))
 	}
 
 	// Check for failure status
@@ -206,9 +206,9 @@ func (c *ArangoClient) handleResponse(resp *http.Response, method, url string, r
 			var aerr ArangoError
 			headers := formatHeaders(resp)
 			if tryDecodeBody(body, &aerr); err == nil {
-				return maskAny(errors.Wrapf(retry.FailureError, "Received status %d, from %s request to %s, which is a failure (attempt %d, started at %s, after %s, error %s, headers\n%s\n)", resp.StatusCode, method, url, attempt, start.Format(startTSFormat), time.Since(start), aerr.Error(), headers))
+				return maskAny(errors.Wrapf(retry.FailureError, "Received status %d, from %s request to %s, which is a failure (attempt %d, started at %s, after %s, error %s, headers\n%s\n)", resp.StatusCode, method, url, aresp.Attempts, start.Format(startTSFormat), time.Since(start), aerr.Error(), headers))
 			}
-			return maskAny(errors.Wrapf(retry.FailureError, "Received status %d, from %s request to %s, which is a failure (attempt %d, started at %s, after %s, headers\n%s\n\nbody\n%s\n)", resp.StatusCode, method, url, attempt, start.Format(startTSFormat), time.Since(start), headers, string(body)))
+			return maskAny(errors.Wrapf(retry.FailureError, "Received status %d, from %s request to %s, which is a failure (attempt %d, started at %s, after %s, headers\n%s\n\nbody\n%s\n)", resp.StatusCode, method, url, aresp.Attempts, start.Format(startTSFormat), time.Since(start), headers, string(body)))
 		}
 	}
 
@@ -221,7 +221,7 @@ func (c *ArangoClient) handleResponse(resp *http.Response, method, url string, r
 			// Found a success status
 			if isSuccessStatusCode(code) && result != nil {
 				if err := json.Unmarshal(body, result); err != nil {
-					return maskAny(errors.Wrapf(err, "Failed decoding response data from %s request to %s (attempt %d, started at %s, after %s, error %v)", method, url, attempt, start.Format(startTSFormat), time.Since(start), err))
+					return maskAny(errors.Wrapf(err, "Failed decoding response data from %s request to %s (attempt %d, started at %s, after %s, error %v)", method, url, aresp.Attempts, start.Format(startTSFormat), time.Since(start), err))
 				}
 			}
 			// Return success
@@ -232,7 +232,7 @@ func (c *ArangoClient) handleResponse(resp *http.Response, method, url string, r
 	// Unexpected status code
 	c.lastCoordinatorURL = nil // Change coordinator
 	headers := formatHeaders(resp)
-	return maskAny(fmt.Errorf("Unexpected status %d from %s request to %s (attempt %d, started at %s, after %s, headers\n%s\n\nbody\n%s\n)", resp.StatusCode, method, url, attempt, start.Format(startTSFormat), time.Since(start), headers, string(body)))
+	return maskAny(fmt.Errorf("Unexpected status %d from %s request to %s (attempt %d, started at %s, after %s, headers\n%s\n\nbody\n%s\n)", resp.StatusCode, method, url, aresp.Attempts, start.Format(startTSFormat), time.Since(start), headers, string(body)))
 }
 
 func tryDecodeBody(body []byte, result interface{}) error {


### PR DESCRIPTION
This PR handles the following cases.

- Update/replace document with an explicit revision fails with 412. 
- Remove document fails with 404.

In both cases a check is added to see if the failure is plausible. 