### PR TITLE
Various updates to support starter 0.10.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ EXPOSE 4200
 ENV RUNNING_IN_DOCKER=true
 
 # Image containing arangodb starter 
-ENV ARANGODB_IMAGE=arangodb/arangodb-starter:0.7
+ENV ARANGODB_IMAGE=arangodb/arangodb-starter:latest
 
 # Database image 
 #ENV ARANGO_IMAGE=arangodb/arangodb:3.1.10
 #ENV ARANGO_IMAGE=neunhoef/arangodb:3.2.devel
-ENV ARANGO_IMAGE=arangodb/arangodb:3.1.19
+ENV ARANGO_IMAGE=arangodb/arangodb:3.3.3
 
 # network-blocker image
 ENV NETWORK_BLOCKER_IMAGE=arangodb/network-blocker:0.1.0

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ REPODIR := $(ORGDIR)/$(REPONAME)
 REPOPATH := $(ORGPATH)/$(REPONAME)
 
 GOPATH := $(GOBUILDDIR)
-GOVERSION := 1.8.3-alpine
+GOVERSION := 1.9.3-alpine
 
 ifndef GOOS
 	GOOS := linux

--- a/pkg/arangostarter/api.go
+++ b/pkg/arangostarter/api.go
@@ -1,57 +1,106 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
 package arangostarter
 
+import "context"
+
+// API is the interface implemented by the starter's HTTP API's.
 type API interface {
-	// PrepareSlave prepare the launch of an arangodb slave.
-	// Given an ID, host, port & dataDir will it reserve a peer slot and return a stable port offset.
-	PrepareSlave(id, hostIP string, port int, dataDir string) (Peer, error)
+	// ID requests the starters ID.
+	ID(ctx context.Context) (IDInfo, error)
 
-	// GetProcesses loads information of all the server processes launched by a specific arangodb.
-	GetProcesses() (ProcessListResponse, error)
+	// Version requests the starter version.
+	Version(ctx context.Context) (VersionInfo, error)
 
-	// Shutdown will shutdown a specific arangodb (and all its started servers).
-	// With goodbye set, it will remove the peer slot for this arangodb instance.
-	Shutdown(goodbye bool) error
+	// Processes loads information of all the database server processes launched by the starter.
+	Processes(ctx context.Context) (ProcessList, error)
+
+	// Endpoints loads the URL's needed to reach all starters, agents & coordinators in the cluster.
+	Endpoints(ctx context.Context) (EndpointList, error)
+
+	// Shutdown will shutdown a starter (and all its started database servers).
+	// With goodbye set, it will remove the peer slot for the starter.
+	Shutdown(ctx context.Context, goodbye bool) error
 
 	// WaitUntilGone will block until the specific arangodb instance can no longer be reached.
-	WaitUntilGone() error
+	WaitUntilGone(ctx context.Context) error
 }
 
-type Peer struct {
-	ID         string // Unique of of the peer
-	Address    string // IP address of arangodb peer server
-	Port       int    // Port number of arangodb peer server
-	PortOffset int    // Offset to add to base ports for the various servers (agent, coordinator, dbserver)
-	DataDir    string // Directory holding my data
-	HasAgent   bool   // If set, this peer is running an agent
+// IDInfo contains the ID of the starter
+type IDInfo struct {
+	ID string `json:"id"`
 }
 
-// Peer information.
-// When this type (or any of the types used in here) is changed, increase `SetupConfigVersion`.
-type Peers struct {
-	Peers      []Peer // All peers (index 0 is reserver for the master)
-	AgencySize int    // Number of agents
+// VersionInfo is the JSON response of a `/version` request.
+type VersionInfo struct {
+	Version string `json:"version"`
+	Build   string `json:"build"`
 }
 
-// PeerByID returns a peer with given id & true, or false if not found.
-func (p Peers) PeerByID(id string) (Peer, bool) {
-	for _, x := range p.Peers {
-		if x.ID == id {
-			return x, true
+// EndpointList is the JSON response of a `/endpoints` request.
+// It contains URL's of all starters, agents & coordinators in the cluster.
+type EndpointList struct {
+	Starters     []string `json:"starters,omitempty"`     // List of URL's to all starter APIs
+	Agents       []string `json:"agents,omitempty"`       // List of URL's to all agents (database servers) in the cluster
+	Coordinators []string `json:"coordinators,omitempty"` // List of URL's to all coordinators (database servers) in the cluster
+}
+
+// ProcessList is the JSON response of a `/process` request.
+type ProcessList struct {
+	ServersStarted bool            `json:"servers-started,omitempty"` // True if the server have all been started
+	Servers        []ServerProcess `json:"servers,omitempty"`         // List of servers started by the starter
+}
+
+// ServerType holds a type of (arangod) server
+type ServerType string
+
+const (
+	ServerTypeCoordinator = ServerType("coordinator")
+	ServerTypeDBServer    = ServerType("dbserver")
+	ServerTypeAgent       = ServerType("agent")
+	ServerTypeSingle      = ServerType("single")
+	ServerTypeSyncMaster  = ServerType("syncmaster")
+	ServerTypeSyncWorker  = ServerType("syncworker")
+)
+
+// ServerProcess holds all information of a single server started by the starter.
+type ServerProcess struct {
+	Type        ServerType `json:"type"`                   // agent | coordinator | dbserver
+	IP          string     `json:"ip"`                     // IP address needed to reach the server
+	Port        int        `json:"port"`                   // Port needed to reach the server
+	ProcessID   int        `json:"pid,omitempty"`          // PID of the process (0 when running in docker)
+	ContainerID string     `json:"container-id,omitempty"` // ID of docker container running the server
+	ContainerIP string     `json:"container-ip,omitempty"` // IP address of docker container running the server
+	IsSecure    bool       `json:"is-secure,omitempty"`    // If set, this server is using an SSL connection
+}
+
+// ServerByType returns the server of given type.
+// If no such server process is found, false is returned.
+func (list ProcessList) ServerByType(serverType ServerType) (ServerProcess, bool) {
+	for _, sp := range list.Servers {
+		if sp.Type == serverType {
+			return sp, true
 		}
 	}
-	return Peer{}, false
-}
-
-type ProcessListResponse struct {
-	ServersStarted bool            `json:"servers-started,omitempty"` // True if the server have all been started
-	Servers        []ServerProcess `json:"servers,omitempty"`         // List of servers started by ArangoDB
-}
-
-type ServerProcess struct {
-	Type        string `json:"type"`                   // agent | coordinator | dbserver
-	IP          string `json:"ip"`                     // IP address needed to reach the server
-	Port        int    `json:"port"`                   // Port needed to reach the server
-	ProcessID   int    `json:"pid,omitempty"`          // PID of the process (0 when running in docker)
-	ContainerID string `json:"container-id,omitempty"` // ID of docker container running the server
-	ContainerIP string `json:"container-ip,omitempty"` // IP address of docker container running the server
+	return ServerProcess{}, false
 }

--- a/pkg/arangostarter/error.go
+++ b/pkg/arangostarter/error.go
@@ -1,9 +1,122 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
 package arangostarter
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/pkg/errors"
 )
 
 var (
 	maskAny = errors.WithStack
+	// ServiceUnavailableError indicates that right now the service is not available, please retry later.
+	ServiceUnavailableError = StatusError{StatusCode: http.StatusServiceUnavailable, message: "service unavailable"}
+	// BadRequestError indicates invalid arguments.
+	BadRequestError = StatusError{StatusCode: http.StatusBadRequest, message: "bad request"}
+	// PreconditionFailedError indicates that the state of the system is such that the request cannot be executed.
+	PreconditionFailedError = StatusError{StatusCode: http.StatusPreconditionFailed, message: "precondition failed"}
+	// InternalServerError indicates an unspecified error inside the server, perhaps a bug.
+	InternalServerError = StatusError{StatusCode: http.StatusInternalServerError, message: "internal server error"}
 )
+
+type StatusError struct {
+	StatusCode int
+	message    string
+}
+
+func (e StatusError) Error() string {
+	if e.message != "" {
+		return e.message
+	}
+	return fmt.Sprintf("Status %d", e.StatusCode)
+}
+
+// IsStatusError returns the status code and true
+// if the given error is caused by a StatusError.
+func IsStatusError(err error) (int, bool) {
+	err = errors.Cause(err)
+	if serr, ok := err.(StatusError); ok {
+		return serr.StatusCode, true
+	}
+	return 0, false
+}
+
+// IsStatusErrorWithCode returns true if the given error is caused
+// by a StatusError with given code.
+func IsStatusErrorWithCode(err error, code int) bool {
+	err = errors.Cause(err)
+	if serr, ok := err.(StatusError); ok {
+		return serr.StatusCode == code
+	}
+	return false
+}
+
+type ErrorResponse struct {
+	Error string
+}
+
+// IsServiceUnavailable returns true if the given error is caused by a ServiceUnavailableError.
+func IsServiceUnavailable(err error) bool {
+	return IsStatusErrorWithCode(err, http.StatusServiceUnavailable)
+}
+
+// IsBadRequest returns true if the given error is caused by a BadRequestError.
+func IsBadRequest(err error) bool {
+	return IsStatusErrorWithCode(err, http.StatusBadRequest)
+}
+
+// IsPreconditionFailed returns true if the given error is caused by a PreconditionFailedError.
+func IsPreconditionFailed(err error) bool {
+	return IsStatusErrorWithCode(err, http.StatusPreconditionFailed)
+}
+
+// IsInternalServer returns true if the given error is caused by a InternalServerError.
+func IsInternalServer(err error) bool {
+	return IsStatusErrorWithCode(err, http.StatusInternalServerError)
+}
+
+// ParseResponseError returns an error from given response.
+// It tries to parse the body (if given body is nil, will be read from response)
+// for ErrorResponse.
+func ParseResponseError(r *http.Response, body []byte) error {
+	// Read body (if needed)
+	if body == nil {
+		defer r.Body.Close()
+		body, _ = ioutil.ReadAll(r.Body)
+	}
+	// Parse body (if available)
+	if len(body) > 0 {
+		var errRes ErrorResponse
+		if err := json.Unmarshal(body, &errRes); err == nil {
+			// Found ErrorResponse
+			return StatusError{StatusCode: r.StatusCode, message: errRes.Error}
+		}
+	}
+
+	// No ErrorResponse found, fallback to default message
+	return StatusError{StatusCode: r.StatusCode}
+}

--- a/pkg/arangostarter/http.go
+++ b/pkg/arangostarter/http.go
@@ -1,0 +1,53 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package arangostarter
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+)
+
+// DefaultHTTPClient creates a new HTTP client configured for accessing a starter.
+func DefaultHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: time.Second * 15,
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+				DualStack: true,
+			}).DialContext,
+			MaxIdleConns:        100,
+			IdleConnTimeout:     90 * time.Second,
+			TLSHandshakeTimeout: 10 * time.Second,
+			TLSClientConfig: &tls.Config{
+				// It is likely that we'll use self-signed certificates, so disable verification by default.
+				InsecureSkipVerify: true,
+			},
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+}

--- a/service/cluster/arangodb/portSpace.go
+++ b/service/cluster/arangodb/portSpace.go
@@ -1,0 +1,48 @@
+package arangodb
+
+import "sync"
+
+type portSpace struct {
+	mutex     sync.Mutex
+	basePort  int
+	portDelta int
+	inUse     map[string]int
+}
+
+// Initialize the structure.
+// Call only once.
+func (s *portSpace) Initialize(basePort, portDelta int) {
+	s.basePort = basePort
+	s.portDelta = portDelta
+	s.inUse = make(map[string]int)
+}
+
+// Allocate a port for given ID
+func (s *portSpace) Allocate(id string) int {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	port := s.basePort + s.portDelta
+	for {
+		found := false
+		for _, p := range s.inUse {
+			if p == port {
+				found = true
+				break
+			}
+		}
+		if !found {
+			s.inUse[id] = port
+			return port
+		}
+		port += s.portDelta
+	}
+}
+
+// Release the port allocated for the given ID
+func (s *portSpace) Release(id string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	delete(s.inUse, id)
+}


### PR DESCRIPTION
This PR contains the following changes:

- Updates default database to 3.3.3
- Updates to starter client API 
- Starter command line argument updates 
- Use own port allocate instead of relying on starter (needed after bootstrapping phase introduction in starter)
- Go update to 1.9.3