### PR TITLE
Add first unit tests for testagent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ BIN := $(BINDIR)/$(BINNAME)
 SOURCES := $(shell find $(SRCDIR) -name '*.go')
 TEMPLATES := $(shell find $(SRCDIR)/templates -name '*.tmpl')
 
-.PHONY: all clean deps docker build build-local
+.PHONY: all clean deps docker build build-local tests
 
 all: docker
 
@@ -60,6 +60,10 @@ endif
 
 localtest:
 	docker run -it --rm --net=host -v $(HOME)/tmp:/reports -v /var/run/docker.sock:/var/run/docker.sock arangodb/testagent --docker-net-host
+
+tests:
+	go test -coverprofile cover.out github.com/arangodb-helper/testagent/tests/simple -v
+	go tool cover -html=cover.out
 
 docker-push-version: docker
 	docker tag arangodb/testagent arangodb/testagent:$(VERSION)

--- a/tests/simple/simple.go
+++ b/tests/simple/simple.go
@@ -246,7 +246,7 @@ func (t *simpleTest) shouldStop() bool {
 
 type UserDocument struct {
 	Key   string `json:"_key"`
-	rev   string // Note that we do not export this field!
+	Rev   string `json:"_rev,omitempty"`
 	Value int    `json:"value"`
 	Name  string `json:"name"`
 	Odd   bool   `json:"odd"`
@@ -755,7 +755,7 @@ func (t *simpleTest) createAndInitCollection() error {
 		if rev, err := t.createDocument(c, userDoc, userDoc.Key); err != nil {
 			t.log.Errorf("Failed to create document: %#v", err)
 		} else {
-			userDoc.rev = rev
+			userDoc.Rev = rev
 			c.existingDocs[userDoc.Key] = userDoc
 		}
 		t.actions++
@@ -784,7 +784,7 @@ func (c *collection) selectRandomKey() (string, string) {
 	index := rand.Intn(len(c.existingDocs))
 	for k, v := range c.existingDocs {
 		if index == 0 {
-			return k, v.rev
+			return k, v.Rev
 		}
 		index--
 	}
@@ -792,10 +792,10 @@ func (c *collection) selectRandomKey() (string, string) {
 }
 
 func (c *collection) selectWrongRevision(key string) (string, bool) {
-	correctRev := c.existingDocs[key].rev
+	correctRev := c.existingDocs[key].Rev
 	for _, v := range c.existingDocs {
-		if v.rev != correctRev && v.rev != "" {
-			return v.rev, true
+		if v.Rev != correctRev && v.Rev != "" {
+			return v.Rev, true
 		}
 	}
 	return "", false // This should never be reached when len(t.existingDocs) > 1

--- a/tests/simple/simple.go
+++ b/tests/simple/simple.go
@@ -42,7 +42,7 @@ type simpleTest struct {
 	pauseRequested                      bool
 	paused                              bool
 	lastRequestErr                      bool
-	client                              *util.ArangoClient
+	client                              util.ArangoClientInterface
 	failures                            int
 	actions                             int
 	collections                         map[string]*collection

--- a/tests/simple/simple_create.go
+++ b/tests/simple/simple_create.go
@@ -8,6 +8,10 @@ import (
 	"github.com/arangodb-helper/testagent/service/test"
 )
 
+var (
+	ReadTimeout int = 128    // to be overwritten in unittests only
+)
+
 // readDocument tries to read a document. It retries up to `seconds` seconds,
 // if timeout or connection refused or 503 happen, so these are never
 // returned. If the document is not found (404), then this is considered
@@ -138,7 +142,7 @@ func (t *simpleTest) createDocument(c *collection, document UserDocument, key st
 		}
 
 		if checkRetry {
-			d, e := readDocument(t, c.name, key, "", 128, false)
+			d, e := readDocument(t, c.name, key, "", ReadTimeout, false)
 			// replace == with Equals
 			if e == nil && d != nil && d.Equals(document) {
 				document.Rev = d.Rev

--- a/tests/simple/simple_create_test.go
+++ b/tests/simple/simple_create_test.go
@@ -1,0 +1,381 @@
+package simple
+
+import (
+	"context"
+	"fmt"
+	"encoding/json"
+  "testing"
+  "time"
+	logging "github.com/op/go-logging"
+
+	"github.com/arangodb-helper/testagent/service"
+	"github.com/arangodb-helper/testagent/service/cluster/arangodb"
+	"github.com/arangodb-helper/testagent/tests/util"
+)
+
+var (
+  log = logging.MustGetLogger("testAgentTests")
+	appFlags struct {
+		port int
+    service.ServiceConfig
+    arangodb.ArangodbConfig
+    SimpleConfig
+    logLevel string
+  }
+  config SimpleConfig = SimpleConfig{
+		MaxDocuments:     20000,
+		MaxCollections:   10,
+		OperationTimeout: time.Second * 1,
+		RetryTimeout:     time.Minute * 4,
+	}
+	coll *collection = &collection{
+		name: "simple_test_collection",
+    existingDocs: make(map[string]UserDocument, 1000),
+	}
+)
+
+func next(ctx context.Context, t *testing.T, requests chan *util.MockRequest, expectMore bool) *util.MockRequest {
+	select {
+	case req := <-requests:
+		if !expectMore {
+			t.Errorf("Did not expect further request.")
+		}
+		return req
+	case <-ctx.Done():
+		if expectMore {
+      t.Errorf("Expecting further requests.")
+		}
+		return nil
+	}
+}
+
+func createDocumentOkBehaviour(
+	ctx context.Context, t *testing.T,
+	requests chan *util.MockRequest, responses chan *util.MockResponse) {
+
+	// Get a normal POST request:
+  req := next(ctx, t, requests, true); if req == nil { return }
+	if req.Method != "POST" {
+		t.Errorf("Got wrong method %s instead of POST.", req.Method)
+	}
+	if req.UrlPath != "/_api/document/" + coll.name {
+		t.Errorf("Got wrong URL path %s instead of /_api/document/%s",
+		         req.UrlPath, coll.name)
+	}
+
+	// Answer with a normal good response:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{ StatusCode: 200, Rev: "abcd1234" },
+		Err: nil,
+	}
+
+	// Get a second document request:
+  req = next(ctx, t, requests, true); if req == nil { return }
+	if req.Method != "POST" {
+		t.Errorf("Got wrong method %s instead of POST.", req.Method)
+	}
+
+	// Respond immediately with a 503:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{ StatusCode: 503 },
+		Err: nil,
+	}
+
+	// Now expect a GET request to see if the document is there, answer
+	// with no:
+  req = next(ctx, t, requests, true); if req == nil { return }
+	if req.Method != "GET" {
+		t.Errorf("Got wrong method %s instead of GET.", req.Method)
+	}
+	if req.UrlPath != "/_api/document/" + coll.name + "/doc2" {
+		t.Errorf("Got wrong URL path %s instead of /_api/document/%s/doc2", req.UrlPath, coll.name)
+	}
+
+	// Respond with not found:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{ StatusCode: 404 },
+		Err:  nil,
+	}
+
+	// Expect another try to POST:
+  req = next(ctx, t, requests, true); if req == nil { return }
+	if req.Method != "POST" {
+		t.Errorf("Got wrong method %s instead of POST.", req.Method)
+	}
+
+	// this time, let a timeout happen:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{ StatusCode: 0 },
+		Err:  nil,
+	}
+
+	// Expect another GET request to see if the document is there, answer
+	// with no:
+  req = next(ctx, t, requests, true); if req == nil { return }
+	if req.Method != "GET" {
+		t.Errorf("Got wrong method %s instead of GET.", req.Method)
+	}
+	if req.UrlPath != "/_api/document/" + coll.name + "/doc2" {
+		t.Errorf("Got wrong URL path %s instead of /_api/document/%s/doc2", req.UrlPath, coll.name)
+	}
+
+	// Respond with not found:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{ StatusCode: 404 },
+		Err:  nil,
+	}
+
+	// Expect another try to POST:
+  req = next(ctx, t, requests, true); if req == nil { return }
+	if req.Method != "POST" {
+		t.Errorf("Got wrong method %s instead of POST.", req.Method)
+	}
+
+	// this time, let a connection refused happen:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{ StatusCode: 1 },
+		Err:  nil,
+	}
+	// No GET in this case!
+
+	// Expect another try to POST:
+  req = next(ctx, t, requests, true); if req == nil { return }
+	if req.Method != "POST" {
+		t.Errorf("Got wrong method %s instead of POST.", req.Method)
+	}
+
+	// finally, it works:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{ StatusCode: 201, Rev: "abc123" },
+		Err:  nil,
+	}
+
+	// Expect another try to POST: (doc3 now)
+  req = next(ctx, t, requests, true); if req == nil { return }
+	if req.Method != "POST" {
+		t.Errorf("Got wrong method %s instead of POST.", req.Method)
+	}
+
+	// Respond with an unexpected status code, this will be a failure:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{ StatusCode: 412 },
+		Err:  fmt.Errorf("Received unexpected status code 412."),
+	}
+
+	// No more requests coming:
+	next(ctx, t, requests, false)
+}
+
+func TestCreateDocumentOkWithRetry(t *testing.T) {
+	test := simpleTest{
+		SimpleConfig: config,
+		reportDir:    ".",
+		log:          log,
+		collections:  make(map[string]*collection),
+	}
+	mockClient := util.NewMockClient(t, createDocumentOkBehaviour)
+  test.client = mockClient
+	test.listener = util.MockListener{}
+	doc := UserDocument{
+    Key: "doc1",
+		Value: 12,
+		Name: "hanswurst",
+		Odd: true,
+  }
+	rev, err := test.createDocument(coll, doc, "doc1")
+	if rev == "" || err != nil {
+		t.Errorf("Unexpected result from createDocument: %v, err: %v", rev, err)
+	}
+	rev, err = test.createDocument(coll, doc, "doc2")
+	if rev == "" || err != nil {
+		t.Errorf("Unexpected result from createDocument: %v, err: %v", rev, err)
+	}
+	rev, err = test.createDocument(coll, doc, "doc3")
+	if rev != "" || err == nil {
+		t.Errorf("Unexpected result from createDocument: %v, err: %v", rev, err)
+	}
+  mockClient.Shutdown()
+}
+
+func createDocumentTimeoutOkBehaviour(
+	ctx context.Context, t *testing.T,
+	requests chan *util.MockRequest, responses chan *util.MockResponse) {
+
+	// Get a normal POST request:
+  req := next(ctx, t, requests, true); if req == nil { return }
+	if req.Method != "POST" {
+		t.Errorf("Got wrong method %s instead of POST.", req.Method)
+	}
+
+	// let a timeout happen:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{ StatusCode: 0 },
+		Err:  nil,
+	}
+
+	// Expect another GET request to see if the document is there, answer
+	// with yes:
+  req = next(ctx, t, requests, true); if req == nil { return }
+	if req.Method != "GET" {
+		t.Errorf("Got wrong method %s instead of GET.", req.Method)
+	}
+	if req.UrlPath != "/_api/document/" + coll.name + "/doc1" {
+		t.Errorf("Got wrong URL path %s instead of /_api/document/%s/doc2", req.UrlPath, coll.name)
+	}
+
+	// Respond with not found:
+	json.Unmarshal([]byte(`{"name":"hanswurst", "value": 12, "odd": true, "_key": "doc1", "_rev": "abc12345"}`),
+	               req.Result)
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{ StatusCode: 200, Rev: "abc12345" },
+		Err:  nil,
+	}
+
+
+	// No more requests coming:
+	next(ctx, t, requests, false)
+}
+
+func TestCreateDocumentTimeoutThenOK(t *testing.T) {
+	test := simpleTest{
+		SimpleConfig: config,
+		reportDir:    ".",
+		log:          log,
+		collections:  make(map[string]*collection),
+	}
+	mockClient := util.NewMockClient(t, createDocumentTimeoutOkBehaviour)
+  test.client = mockClient
+	test.listener = util.MockListener{}
+	doc := UserDocument{
+    Key: "doc1",
+		Value: 12,
+		Name: "hanswurst",
+		Odd: true,
+  }
+	rev, err := test.createDocument(coll, doc, "doc1")
+	if rev == "" || err != nil {
+		t.Errorf("Unexpected result from createDocument: %v, err: %v", rev, err)
+	}
+  mockClient.Shutdown()
+}
+
+func createDocumentOverallTimeout(
+	ctx context.Context, t *testing.T,
+	requests chan *util.MockRequest, responses chan *util.MockResponse) {
+
+  var req *util.MockRequest
+	for {
+		// Get a normal POST request:
+		select {  // here, we do not know if we expect another one or not
+		case req = <-requests:
+		case <-ctx.Done():
+			return
+		}
+		if req.Method != "POST" {
+			t.Errorf("Got wrong method %s instead of POST.", req.Method)
+		}
+
+		// let a timeout happen:
+		responses <- &util.MockResponse{
+			Resp: util.ArangoResponse{ StatusCode: 0 },
+			Err:  nil,
+		}
+
+		// Expect another GET request to see if the document is there, answer
+		// with yes:
+		req = next(ctx, t, requests, true); if req == nil { return }
+		if req.Method != "GET" {
+			t.Errorf("Got wrong method %s instead of GET.", req.Method)
+		}
+
+		// Respond with not found:
+		responses <- &util.MockResponse{
+			Resp: util.ArangoResponse{ StatusCode: 404 },
+			Err:  nil,
+		}
+	}
+}
+
+func TestCreateDocumentOverallTimeout(t *testing.T) {
+	test := simpleTest{
+		SimpleConfig: config,
+		reportDir:    ".",
+		log:          log,
+		collections:  make(map[string]*collection),
+	}
+	mockClient := util.NewMockClient(t, createDocumentOverallTimeout)
+  test.client = mockClient
+	test.listener = util.MockListener{}
+	doc := UserDocument{
+    Key: "doc1",
+		Value: 12,
+		Name: "hanswurst",
+		Odd: true,
+  }
+	rev, err := test.createDocument(coll, doc, "doc1")
+	if rev != "" || err == nil {
+		t.Errorf("Unexpected result from createDocument: %v, err: %v", rev, err)
+	}
+  mockClient.Shutdown()
+}
+
+func createDocumentReadTimeout(
+	ctx context.Context, t *testing.T,
+	requests chan *util.MockRequest, responses chan *util.MockResponse) {
+
+	// Get a normal POST request:
+  req := next(ctx, t, requests, true); if req == nil { return }
+	if req.Method != "POST" {
+		t.Errorf("Got wrong method %s instead of POST.", req.Method)
+	}
+
+	// let a timeout happen:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{ StatusCode: 0 },
+		Err:  nil,
+	}
+
+	for {
+		// Get a sequence of read requests:
+		select {  // here, we do not know if we expect another one or not
+		case req = <-requests:
+		case <-ctx.Done():
+			return
+		}
+		if req.Method != "GET" {
+			t.Errorf("Got wrong method %s instead of GET.", req.Method)
+		}
+
+		// let a timeout happen:
+		responses <- &util.MockResponse{
+			Resp: util.ArangoResponse{ StatusCode: 0 },
+			Err:  nil,
+		}
+	}
+}
+
+func TestCreateDocumentReadTimeout(t *testing.T) {
+	ReadTimeout = 5   // to speed up timeout failure, needs to be longer than
+	                  // operationTimeout*4, which is 4
+	test := simpleTest{
+		SimpleConfig: config,
+		reportDir:    ".",
+		log:          log,
+		collections:  make(map[string]*collection),
+	}
+	mockClient := util.NewMockClient(t, createDocumentReadTimeout)
+  test.client = mockClient
+	test.listener = util.MockListener{}
+	doc := UserDocument{
+    Key: "doc1",
+		Value: 12,
+		Name: "hanswurst",
+		Odd: true,
+  }
+	rev, err := test.createDocument(coll, doc, "doc1")
+	if rev != "" || err == nil {
+		t.Errorf("Unexpected result from createDocument: %v, err: %v", rev, err)
+	}
+  mockClient.Shutdown()
+}
+

--- a/tests/simple/simple_query_update.go
+++ b/tests/simple/simple_query_update.go
@@ -63,7 +63,7 @@ func (t *simpleTest) queryUpdateDocuments(c *collection, key string) (string, er
 			t.queryUpdateCounter.succeeded++
 			t.log.Infof("Creating update AQL query for collection '%s' succeeded", c.name)
 
-			return resultDocument.rev, nil
+			return resultDocument.Rev, nil
 		}
 
 		// In all other cases we simply try again. Note that this includes the
@@ -139,7 +139,7 @@ func (t *simpleTest) queryUpdateDocumentsLongRunning(c *collection, key string) 
 			t.queryUpdateLongRunningCounter.succeeded++
 			t.log.Infof("Creating long running update AQL query for collection '%s' succeeded", c.name)
 
-			return resultDocument.rev, nil
+			return resultDocument.Rev, nil
 		}
 
 		// In all other cases we simply try again. Note that this includes the

--- a/tests/simple/simple_read.go
+++ b/tests/simple/simple_read.go
@@ -59,7 +59,7 @@ func (t *simpleTest) readExistingDocument(
 				}
 				t.readExistingCounter.succeeded++
 				t.log.Infof("Reading existing document '%s' (%s) from '%s' succeeded", key, ifMatchStatus, c.name)
-				return result.rev, nil
+				return result.Rev, nil
 			}
 		}
 

--- a/tests/simple/simple_read.go
+++ b/tests/simple/simple_read.go
@@ -49,7 +49,7 @@ func (t *simpleTest) readExistingDocument(
 					if !result.Equals(expected) {
 						// This is a failure
 						t.readExistingCounter.failed++
-						t.reportFailure(test.NewFailure("Read existing document '%s' (%s) returned different values '%s': got %q expected %q", key, ifMatchStatus, c.name, result, expected))
+						t.reportFailure(test.NewFailure("Read existing document '%s' (%s) returned different values '%s': got %v expected %v", key, ifMatchStatus, c.name, result, expected))
 						return "", maskAny(fmt.Errorf("Read returned invalid values"))
 					}
 				}

--- a/tests/simple/simple_remove.go
+++ b/tests/simple/simple_remove.go
@@ -69,7 +69,7 @@ func (t *simpleTest) removeExistingDocument(collectionName string, key, rev stri
 		}
 
 		if checkRetry {
-			d, e := readDocument(t, collectionName, key, "", 128, false)
+			d, e := readDocument(t, collectionName, key, "", ReadTimeout, false)
 			if e == nil && d == nil {
 				success = true
 			}

--- a/tests/simple/simple_replace.go
+++ b/tests/simple/simple_replace.go
@@ -98,7 +98,7 @@ func (t *simpleTest) replaceExistingDocument(c *collection, key, rev string) (st
 
 		if checkRetry {
 			expected := c.existingDocs[key]
-			d, e := readDocument(t, c.name, key, "", 128, true)
+			d, e := readDocument(t, c.name, key, "", ReadTimeout, true)
 
 			if e == nil {
 

--- a/tests/simple/simple_replace.go
+++ b/tests/simple/simple_replace.go
@@ -91,6 +91,7 @@ func (t *simpleTest) replaceExistingDocument(c *collection, key, rev string) (st
 				// successful in changing the document.
 				checkRetry = true
 			} else if update[0].StatusCode != 1 {
+			  newDoc.Rev = update[0].Rev
 				success = true
 			}
 		}
@@ -102,6 +103,7 @@ func (t *simpleTest) replaceExistingDocument(c *collection, key, rev string) (st
 			if e == nil {
 
 				if d.Equals(newDoc) {
+					newDoc.Rev = d.Rev
 					success = true
 				} else if !d.Equals(expected) {
 					t.replaceExistingCounter.failed++
@@ -123,13 +125,12 @@ func (t *simpleTest) replaceExistingDocument(c *collection, key, rev string) (st
 
 		if success {
 			// Update memory
-			newDoc.rev = update[0].Rev
 			c.existingDocs[key] = newDoc
 			t.replaceExistingCounter.succeeded++
 			t.log.Infof(
 				"Replacing existing document '%s' (%s) in '%s' (name -> '%s') succeeded",
 				key, ifMatchStatus, c.name, newName)
-			return update[0].Rev, nil
+			return newDoc.Rev, nil
 		}
 
 		time.Sleep(backoff)

--- a/tests/simple/simple_update.go
+++ b/tests/simple/simple_update.go
@@ -102,7 +102,7 @@ func (t *simpleTest) updateExistingDocument(c *collection, key, rev string) (str
 		if checkRetry {
 			expected := c.existingDocs[key]
 			expected.Name = newName
-			d, e := readDocument(t, c.name, key, "", 128, true)
+			d, e := readDocument(t, c.name, key, "", ReadTimeout, true)
 
 			if e == nil { // document does not exist
 				if d.Equals(expected) {

--- a/tests/simple/simple_update.go
+++ b/tests/simple/simple_update.go
@@ -88,6 +88,7 @@ func (t *simpleTest) updateExistingDocument(c *collection, key, rev string) (str
 				// 0, 409, 503 -> check if not accidentally successful
 				checkRetry = true
 			} else if update[0].StatusCode != 1 {
+			  doc.Rev = update[0].Rev
 				success = true
 			}
 		} else { // failure
@@ -105,6 +106,7 @@ func (t *simpleTest) updateExistingDocument(c *collection, key, rev string) (str
 
 			if e == nil { // document does not exist
 				if d.Equals(expected) {
+			    doc.Rev = d.Rev
 					success = true
 				} else if !d.Equals(doc) {
 					// If we see the existing one, we simply try again on the grounds
@@ -133,13 +135,12 @@ func (t *simpleTest) updateExistingDocument(c *collection, key, rev string) (str
 		if success {
 			// Update memory
 			doc.Name = newName
-			doc.rev = update[0].Rev
 			c.existingDocs[key] = doc
 			t.updateExistingCounter.succeeded++
 			t.log.Infof(
 				"Updating existing document '%s' (%s) in '%s' (name -> '%s') succeeded",
 				key, ifMatchStatus, c.name, newName)
-			return update[0].Rev, nil
+			return doc.Rev, nil
 		}
 
 		time.Sleep(backoff)

--- a/tests/util/arango_client.go
+++ b/tests/util/arango_client.go
@@ -51,6 +51,29 @@ type ArangoResponse struct {
 	Rev            string // Revision of document as returned by database (not set for all operations)
 }
 
+type ArangoClientInterface interface {
+  SetCoordinator(coordinatorURL string) error
+  Get(urlPath string, query url.Values, header map[string]string,
+      result interface{},
+			successStatusCodes, failureStatusCodes []int,
+		  operationTimeout time.Duration, retries int) ([]ArangoResponse, []error)
+  Delete(urlPath string, query url.Values, header map[string]string,
+			successStatusCodes, failureStatusCodes []int,
+		  operationTimeout time.Duration, retries int) ([]ArangoResponse, []error)
+  Post(urlPath string, query url.Values, header map[string]string,
+      input interface{}, contentType string, result interface{},
+			successStatusCodes, failureStatusCodes []int,
+		  operationTimeout time.Duration, retries int) ([]ArangoResponse, []error)
+  Patch(urlPath string, query url.Values, header map[string]string,
+      input interface{}, contentType string, result interface{},
+			successStatusCodes, failureStatusCodes []int,
+		  operationTimeout time.Duration, retries int) ([]ArangoResponse, []error)
+  Put(urlPath string, query url.Values, header map[string]string,
+      input interface{}, contentType string, result interface{},
+			successStatusCodes, failureStatusCodes []int,
+		  operationTimeout time.Duration, retries int) ([]ArangoResponse, []error)
+}
+
 func (e ArangoError) Error() string {
 	return fmt.Sprintf("%s: (code %d, errorNum %d)", e.ErrorMessage, e.Code, e.ErrorNum)
 }

--- a/tests/util/arango_client.go
+++ b/tests/util/arango_client.go
@@ -13,10 +13,8 @@ import (
 	"strings"
 	"time"
 
-	//"github.com/arangodb-helper/testagent/pkg/retry"
 	"github.com/arangodb-helper/testagent/service/cluster"
 	logging "github.com/op/go-logging"
-	//"github.com/pkg/errors"
 )
 
 func NewArangoClient(log *logging.Logger, cluster cluster.Cluster) *ArangoClient {

--- a/tests/util/mock_client.go
+++ b/tests/util/mock_client.go
@@ -1,0 +1,138 @@
+package util
+
+import (
+	"context"
+  "net/url"
+	"sync"
+	"testing"
+  "time"
+
+	"github.com/arangodb-helper/testagent/service/test"
+)
+
+type MockRequest struct {
+  Method string
+  UrlPath string
+  Query url.Values
+  Header map[string]string
+  Input interface{}
+  ContentType string
+  Result interface{}
+}
+
+type MockResponse struct {
+  Resp   ArangoResponse
+  Err    error
+}
+
+type MockClient struct {
+	test *testing.T
+	cancel context.CancelFunc
+	ctx context.Context
+  requests chan *MockRequest
+  responses chan *MockResponse
+  behaviour func(context.Context, *testing.T, chan *MockRequest, chan *MockResponse)
+	Wg sync.WaitGroup
+}
+
+type MockListener struct {
+	// so far a black hole
+}
+
+func (ml MockListener) ReportFailure(f test.Failure) {
+}
+
+func NewMockClient(t *testing.T, behaviour func(context.Context, *testing.T, chan *MockRequest, chan *MockResponse)) *MockClient {
+  mockClient := &MockClient{
+		test:      t,
+    requests:  make(chan *MockRequest),
+    responses: make(chan *MockResponse),
+    behaviour: behaviour,
+		Wg:        sync.WaitGroup{},
+  }
+	mockClient.ctx, mockClient.cancel = context.WithCancel(context.Background())
+	mockClient.Wg.Add(1)
+  go func() {
+		mockClient.behaviour(mockClient.ctx, mockClient.test, mockClient.requests, mockClient.responses)
+		mockClient.Wg.Done()
+	}()
+  return mockClient
+}
+
+func (mc *MockClient) SetCoordinator(coordinatorURL string) error {
+  return nil
+}
+
+func (mc *MockClient) Get(urlPath string, query url.Values,
+      header map[string]string, result interface{},
+			successStatusCodes, failureStatusCodes []int,
+		  operationTimeout time.Duration, retries int) ([]ArangoResponse, []error) {
+  req := MockRequest{
+		Method: "GET",
+    UrlPath: urlPath, Query: query, Header: header, Result: result,
+  }
+  mc.requests <- &req
+  resp := <-mc.responses
+  return []ArangoResponse{resp.Resp}, []error{resp.Err}
+}
+
+func (mc *MockClient) Delete(urlPath string, query url.Values,
+      header map[string]string,
+			successStatusCodes, failureStatusCodes []int,
+		  operationTimeout time.Duration, retries int) ([]ArangoResponse, []error) {
+  req := MockRequest{
+		Method: "DELETE",
+    UrlPath: urlPath, Query: query, Header: header,
+  }
+  mc.requests <- &req
+  resp := <-mc.responses
+  return []ArangoResponse{resp.Resp}, []error{resp.Err}
+}
+
+func (mc *MockClient) Post(urlPath string, query url.Values, header map[string]string,
+      input interface{}, contentType string, result interface{},
+			successStatusCodes, failureStatusCodes []int,
+		  operationTimeout time.Duration, retries int) ([]ArangoResponse, []error) {
+  req := MockRequest{
+		Method: "POST",
+		UrlPath: urlPath, Query: query, Header: header, Input: input,
+		ContentType: contentType, Result: result,
+  }
+  mc.requests <- &req
+  resp := <-mc.responses
+  return []ArangoResponse{resp.Resp}, []error{resp.Err}
+}
+
+func (mc *MockClient) Patch(urlPath string, query url.Values, header map[string]string,
+      input interface{}, contentType string, result interface{},
+			successStatusCodes, failureStatusCodes []int,
+		  operationTimeout time.Duration, retries int) ([]ArangoResponse, []error) {
+  req := MockRequest{
+		Method: "PATCH",
+		UrlPath: urlPath, Query: query, Header: header, Input: input,
+		ContentType: contentType, Result: result,
+  }
+  mc.requests <- &req
+  resp := <-mc.responses
+  return []ArangoResponse{resp.Resp}, []error{resp.Err}
+}
+
+func (mc *MockClient) Put(urlPath string, query url.Values, header map[string]string,
+      input interface{}, contentType string, result interface{},
+			successStatusCodes, failureStatusCodes []int,
+		  operationTimeout time.Duration, retries int) ([]ArangoResponse, []error) {
+  req := MockRequest{
+		Method: "PUT",
+		UrlPath: urlPath, Query: query, Header: header, Input: input,
+		ContentType: contentType, Result: result,
+  }
+  mc.requests <- &req
+  resp := <-mc.responses
+  return []ArangoResponse{resp.Resp}, []error{resp.Err}
+}
+
+func (mc *MockClient) Shutdown() {
+	mc.cancel()
+	mc.Wg.Wait()
+}
+


### PR DESCRIPTION
Add unit test frame work and first unit tests for create document.

- Make client into an interface.
- Remove non longer needed dependencies.
- Please compiler in tests.
- Fix rev handling.
- Make readDocument timeout configurable for tests.
- New tests for create document method.
