### PR TITLE
Fix false positive when initial import is incomplete for arangodb <= 3.7

### DIFF
--- a/templates/templates.go
+++ b/templates/templates.go
@@ -88,7 +88,7 @@ func baseFooterTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "base/footer.tmpl", size: 22, mode: os.FileMode(420), modTime: time.Unix(1486974991, 0)}
+	info := bindataFileInfo{name: "base/footer.tmpl", size: 22, mode: os.FileMode(436), modTime: time.Unix(1486974991, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -108,7 +108,7 @@ func baseHeadTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "base/head.tmpl", size: 290, mode: os.FileMode(420), modTime: time.Unix(1486974991, 0)}
+	info := bindataFileInfo{name: "base/head.tmpl", size: 290, mode: os.FileMode(436), modTime: time.Unix(1486974991, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -128,7 +128,7 @@ func chaosTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "chaos.tmpl", size: 1485, mode: os.FileMode(420), modTime: time.Unix(1486974991, 0)}
+	info := bindataFileInfo{name: "chaos.tmpl", size: 1485, mode: os.FileMode(436), modTime: time.Unix(1486974991, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -148,7 +148,7 @@ func indexTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "index.tmpl", size: 3985, mode: os.FileMode(420), modTime: time.Unix(1486974991, 0)}
+	info := bindataFileInfo{name: "index.tmpl", size: 3985, mode: os.FileMode(436), modTime: time.Unix(1486974991, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -168,7 +168,7 @@ func publicStyleCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "public/style.css", size: 369, mode: os.FileMode(420), modTime: time.Unix(1486974991, 0)}
+	info := bindataFileInfo{name: "public/style.css", size: 369, mode: os.FileMode(436), modTime: time.Unix(1486974991, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -188,7 +188,7 @@ func testTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "test.tmpl", size: 1092, mode: os.FileMode(420), modTime: time.Unix(1486974991, 0)}
+	info := bindataFileInfo{name: "test.tmpl", size: 1092, mode: os.FileMode(436), modTime: time.Unix(1486974991, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/tests/simple/simple.go
+++ b/tests/simple/simple.go
@@ -701,7 +701,6 @@ func (t *simpleTest) createAndInitCollection() error {
 		t.reportFailure(test.NewFailure("Creating collection '%s' failed: %v", c.name, err))
 		return maskAny(err)
 	}
-	t.registerCollection(c)
 	t.createCollectionCounter.succeeded++
 	t.actions++
 
@@ -710,6 +709,7 @@ func (t *simpleTest) createAndInitCollection() error {
 		t.log.Errorf("Failed to import documents: %#v", err)
 	}
 	t.actions++
+	t.registerCollection(c)
 
 	// Check imported documents
 	for k := range c.existingDocs {

--- a/tests/simple/simple.go
+++ b/tests/simple/simple.go
@@ -707,6 +707,7 @@ func (t *simpleTest) createAndInitCollection() error {
 	// Import documents
 	if err := t.importDocuments(c); err != nil {
 		t.log.Errorf("Failed to import documents: %#v", err)
+		return maskAny(err)
 	}
 	t.actions++
 	t.registerCollection(c)

--- a/tests/simple/simple_import.go
+++ b/tests/simple/simple_import.go
@@ -40,6 +40,7 @@ func (t *simpleTest) importDocuments(c *collection) error {
 	q := url.Values{}
 	q.Set("collection", c.name)
 	q.Set("waitForSync", "true")
+	q.Set("details", "true")
 	importData, docs := t.createImportDocument()
 	t.log.Infof("Importing %d documents ('%s' - '%s') into '%s'...", len(docs), docs[0].Key, docs[len(docs)-1].Key, c.name)
 	var result interface{}


### PR DESCRIPTION
Fix false positive when initial import is incomplete for arangodb <= 3.7
Check #created from result array to match with ndcs. If smaller, do not register the collection, record error but no failure, move on. 