### PR TITLE
Adjust test behaviour after documentation change(APM-185)

### DIFF
--- a/tests/simple/simple_collection.go
+++ b/tests/simple/simple_collection.go
@@ -42,7 +42,7 @@ func (t *simpleTest) createCollection(c *collection, numberOfShards, replication
 		t.log.Infof("Creating (%d) collection '%s' with numberOfShards=%d, replicationFactor=%d...",
 			i, c.name, numberOfShards, replicationFactor)
 		resp, err := t.client.Post(
-			"/_api/collection", nil, nil, opts, "", nil, []int{0, 1, 200, 409, 500, 503},
+			"/_api/collection", nil, nil, opts, "", nil, []int{0, 1, 200, 409, 500, 503, 410},
 			[]int{400, 404, 307}, operationTimeout, 1)
 		t.log.Infof("... got http %d - arangodb %d via %s",
 			resp[0].StatusCode, resp[0].Error_.ErrorNum, resp[0].CoordinatorURL)
@@ -51,7 +51,7 @@ func (t *simpleTest) createCollection(c *collection, numberOfShards, replication
 		//     there: good
 		//     not there: retry
 		// 200   : good
-		// 1, 500: collection couldn't be finished.
+		// 1, 500, 410: collection couldn't be finished.
 		//     there: failure
 		//     not there: retry
 		// 409   :
@@ -65,7 +65,7 @@ func (t *simpleTest) createCollection(c *collection, numberOfShards, replication
 			if resp[0].StatusCode == 200 {
 				success = true
 			} else {
-				if resp[0].StatusCode == 1 || resp[0].StatusCode == 500 { // connection refused or not created
+				if resp[0].StatusCode == 1 || resp[0].StatusCode == 500 || resp[0].StatusCode == 410 { // connection refused or not created
 					checkRetry = true
 					shouldNotExist = true
 				} else if resp[0].StatusCode == 409 {
@@ -160,7 +160,7 @@ func (t *simpleTest) removeExistingCollection(c *collection) error {
 
 		t.log.Infof("Removing (%d) collection '%s'...", i, c.name)
 		resp, err := t.client.Delete(
-			url, nil, nil, []int{0, 1, 200, 404, 500, 503}, []int{400, 409, 307}, operationTimeout, 1)
+			url, nil, nil, []int{0, 1, 200, 404, 410, 500, 503}, []int{400, 409, 307}, operationTimeout, 1)
 		t.log.Infof("... got http %d - arangodb %d", resp[0].StatusCode, resp[0].Error_.ErrorNum)
 
 		if err[0] != nil {
@@ -224,7 +224,7 @@ func (t *simpleTest) collectionExists(c *collection) (bool, error) {
 
 		t.log.Infof("Checking (%d) collection '%s'...", i, c.name)
 		resp, err := t.client.Get(
-			url, nil, nil, nil, []int{0, 1, 200, 404, 503}, []int{400, 409, 307}, operationTimeout, 1)
+			url, nil, nil, nil, []int{0, 1, 200, 404, 410, 503}, []int{400, 409, 307}, operationTimeout, 1)
 		t.log.Infof("... got http %d - arangodb %d", resp[0].StatusCode, resp[0].Error_.ErrorNum)
 
 		if err[0] != nil {
@@ -237,7 +237,7 @@ func (t *simpleTest) collectionExists(c *collection) (bool, error) {
 			return true, nil
 		}
 
-		// 0, 1, 503 retry
+		// 0, 1, 410, 503 retry
 		time.Sleep(backoff)
 		if backoff < time.Second*5 {
 			backoff += backoff

--- a/tests/simple/simple_collection_test.go
+++ b/tests/simple/simple_collection_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	foo *collection = &collection{
-		name:         "foo",
+	foo *collection = &collection {
+		name: "foo",
 		existingDocs: map[string]UserDocument{},
 	}
 )
@@ -35,7 +35,7 @@ func createCollectionOk(
 	// Answer with a normal good response:
 	// Respond with found:
 	responses <- &util.MockResponse{
-		Resp: util.ArangoResponse{StatusCode: 200},
+		Resp: util.ArangoResponse { StatusCode: 200, },
 		Err:  nil,
 	}
 
@@ -74,7 +74,7 @@ func createCollectionRedirectFail(
 	}
 	responses <- &util.MockResponse{
 		Resp: util.ArangoResponse{},
-		Err:  fmt.Errorf("Error"),
+		Err: fmt.Errorf("Error"),
 	}
 	// No more requests coming:
 	next(ctx, t, requests, false)
@@ -118,7 +118,7 @@ func createCollectionTestTimeoutFail(
 		// Answer with a normal good response:
 		// Respond with found:
 		responses <- &util.MockResponse{
-			Resp: util.ArangoResponse{StatusCode: 503},
+			Resp: util.ArangoResponse { StatusCode: 503, },
 			Err:  nil,
 		}
 		// Get a normal POST request (as preparation)
@@ -131,7 +131,7 @@ func createCollectionTestTimeoutFail(
 		}
 		// Respond with not found:
 		responses <- &util.MockResponse{
-			Resp: util.ArangoResponse{StatusCode: 404},
+			Resp: util.ArangoResponse { StatusCode: 404, },
 			Err:  nil,
 		}
 	}
@@ -173,7 +173,7 @@ func createCollectionReadTimeoutFail(
 	// Answer with a normal good response:
 	// Respond with found:
 	responses <- &util.MockResponse{
-		Resp: util.ArangoResponse{StatusCode: 503},
+			Resp: util.ArangoResponse { StatusCode: 503, },
 		Err:  nil,
 	}
 	for {
@@ -187,7 +187,7 @@ func createCollectionReadTimeoutFail(
 		}
 		// Respond with temporarily unavailable:
 		responses <- &util.MockResponse{
-			Resp: util.ArangoResponse{StatusCode: 503},
+			Resp: util.ArangoResponse { StatusCode: 503, },
 			Err:  nil,
 		}
 	}
@@ -230,7 +230,7 @@ func createCollectionCreateReadErrorFail(
 	}
 	// Answer with temporarily not available:
 	responses <- &util.MockResponse{
-		Resp: util.ArangoResponse{StatusCode: 503},
+		Resp: util.ArangoResponse { StatusCode: 503, },
 		Err:  nil,
 	}
 
@@ -243,7 +243,7 @@ func createCollectionCreateReadErrorFail(
 	}
 	// Answer with a error:
 	responses <- &util.MockResponse{
-		Resp: util.ArangoResponse{},
+		Resp: util.ArangoResponse {},
 		Err:  fmt.Errorf("error"),
 	}
 
@@ -294,12 +294,13 @@ func createCollectionTimeoutOk(
 		return
 	}
 	responses <- &util.MockResponse{
-		Resp: util.ArangoResponse{StatusCode: 200},
+		Resp: util.ArangoResponse { StatusCode: 200, },
 		Err:  nil,
 	}
 	// No more requests coming:
 	next(ctx, t, requests, false)
 }
+
 
 func TestCollectionCreateTimeoutOk(t *testing.T) {
 	test := simpleTest{
@@ -347,7 +348,7 @@ func createCollectionUnknownOk(
 		t.Errorf("Got wrong method %s instead of GET.", req.Method)
 	}
 	responses <- &util.MockResponse{
-		Resp: util.ArangoResponse{StatusCode: 200},
+		Resp: util.ArangoResponse { StatusCode: 200, },
 		Err:  nil,
 	}
 	// No more requests coming:
@@ -518,7 +519,7 @@ func createCollectionRefusedExistsFail(
 		t.Errorf("Got wrong method %s instead of GET.", req.Method)
 	}
 	responses <- &util.MockResponse{
-		Resp: util.ArangoResponse{StatusCode: 200},
+		Resp: util.ArangoResponse { StatusCode: 200, },
 		Err:  nil,
 	}
 	// No more requests coming:
@@ -567,7 +568,7 @@ func createCollectionUnfinishedExistsFail(
 		return
 	}
 	responses <- &util.MockResponse{
-		Resp: util.ArangoResponse{StatusCode: 200},
+		Resp: util.ArangoResponse { StatusCode: 200, },
 		Err:  nil,
 	}
 	// No more requests coming:
@@ -592,6 +593,7 @@ func TestCollectionCreateUnfinishedExistsFail(t *testing.T) {
 	}
 	mockClient.Shutdown()
 }
+
 
 func createCollectionConflictFirstAttemptFail(
 	ctx context.Context, t *testing.T,
@@ -632,6 +634,7 @@ func TestCollectionCreateConflictFirstAttemptFail(t *testing.T) {
 	}
 	mockClient.Shutdown()
 }
+
 
 func createCollectionConflictLaterAttemptExistsOk(
 	ctx context.Context, t *testing.T,
@@ -785,6 +788,7 @@ func TestCollectionCreateConflictLaterAttemptNotExistsFail(t *testing.T) {
 	mockClient.Shutdown()
 }
 
+
 func removeExistingCollectionOk(
 	ctx context.Context, t *testing.T,
 	requests chan *util.MockRequest, responses chan *util.MockResponse) {
@@ -802,7 +806,7 @@ func removeExistingCollectionOk(
 		t.Errorf("Got wrong URL path %s instead of %s", req.UrlPath, path)
 	}
 	responses <- &util.MockResponse{
-		Resp: util.ArangoResponse{StatusCode: 200},
+		Resp: util.ArangoResponse { StatusCode: 200, },
 		Err:  nil,
 	}
 	// No more requests coming:
@@ -888,7 +892,7 @@ func removeExistingCollectionMissingFirstFail(
 		t.Errorf("Got wrong URL path %s instead of %s", req.UrlPath, path)
 	}
 	responses <- &util.MockResponse{
-		Resp: util.ArangoResponse{StatusCode: 404},
+		Resp: util.ArangoResponse { StatusCode: 404, },
 		Err:  nil,
 	}
 	// No more requests coming:
@@ -988,7 +992,7 @@ func removeExistingCollectionMissingLaterOk(
 		t.Errorf("Got wrong URL path %s instead of %s", req.UrlPath, path)
 	}
 	responses <- &util.MockResponse{
-		Resp: util.ArangoResponse{StatusCode: 503},
+		Resp: util.ArangoResponse { StatusCode: 503, },
 		Err:  nil,
 	}
 	req = next(ctx, t, requests, true)
@@ -1002,7 +1006,7 @@ func removeExistingCollectionMissingLaterOk(
 		t.Errorf("Got wrong URL path %s instead of %s", req.UrlPath, path)
 	}
 	responses <- &util.MockResponse{
-		Resp: util.ArangoResponse{StatusCode: 404},
+		Resp: util.ArangoResponse { StatusCode: 404, },
 		Err:  nil,
 	}
 	// No more requests coming:
@@ -1048,7 +1052,7 @@ func removeExistingCollectionTimeoutFail(
 			t.Errorf("Got wrong URL path %s instead of %s", req.UrlPath, path)
 		}
 		responses <- &util.MockResponse{
-			Resp: util.ArangoResponse{StatusCode: 503},
+			Resp: util.ArangoResponse { StatusCode: 503, },
 			Err:  nil,
 		}
 	}
@@ -1075,3 +1079,4 @@ func TestCollectionExistingRemoveTimeoutFail(t *testing.T) {
 	}
 	mockClient.Shutdown()
 }
+

--- a/tests/simple/simple_create_test.go
+++ b/tests/simple/simple_create_test.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	logging "github.com/op/go-logging"
 	"testing"
 	"time"
-
-	logging "github.com/op/go-logging"
 
 	"github.com/arangodb-helper/testagent/service"
 	"github.com/arangodb-helper/testagent/service/cluster/arangodb"

--- a/tests/simple/simple_create_test.go
+++ b/tests/simple/simple_create_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	logging "github.com/op/go-logging"
 	"testing"
 	"time"
+
+	logging "github.com/op/go-logging"
 
 	"github.com/arangodb-helper/testagent/service"
 	"github.com/arangodb-helper/testagent/service/cluster/arangodb"
@@ -93,6 +94,40 @@ func createDocumentOkBehaviour(
 	// Respond immediately with a 503:
 	responses <- &util.MockResponse{
 		Resp: util.ArangoResponse{StatusCode: 503},
+		Err:  nil,
+	}
+
+	// Now expect a GET request to see if the document is there, answer
+	// with no:
+	req = next(ctx, t, requests, true)
+	if req == nil {
+		return
+	}
+	if req.Method != "GET" {
+		t.Errorf("Got wrong method %s instead of GET.", req.Method)
+	}
+	if req.UrlPath != "/_api/document/"+coll.name+"/doc2" {
+		t.Errorf("Got wrong URL path %s instead of /_api/document/%s/doc2", req.UrlPath, coll.name)
+	}
+
+	// Respond with not found:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{StatusCode: 404},
+		Err:  nil,
+	}
+
+	// Expect another try to POST:
+	req = next(ctx, t, requests, true)
+	if req == nil {
+		return
+	}
+	if req.Method != "POST" {
+		t.Errorf("Got wrong method %s instead of POST.", req.Method)
+	}
+
+	// Respond immediately with a 410:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{StatusCode: 410},
 		Err:  nil,
 	}
 
@@ -419,6 +454,83 @@ func TestCreateDocumentReadTimeout(t *testing.T) {
 	rev, err := test.createDocument(coll, doc, "doc1")
 	if rev != "" || err == nil {
 		t.Errorf("Unexpected result from createDocument: %v, err: %v", rev, err)
+	}
+	mockClient.Shutdown()
+}
+
+func createDocumentGoneButCreatedBehaviour(
+	ctx context.Context, t *testing.T,
+	requests chan *util.MockRequest, responses chan *util.MockResponse) {
+
+	// Get a POST request:
+	req := next(ctx, t, requests, true)
+	if req == nil {
+		return
+	}
+	if req.Method != "POST" {
+		t.Errorf("Got wrong method %s instead of POST.", req.Method)
+	}
+	if req.UrlPath != "/_api/document/"+coll.name {
+		t.Errorf("Got wrong URL path %s instead of /_api/document/%s",
+			req.UrlPath, coll.name)
+	}
+
+	newDoc := req.Input.(UserDocument)
+
+	// Answer with 410:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{StatusCode: 410},
+		Err:  nil,
+	}
+
+	// Get a GET request:
+	req = next(ctx, t, requests, true)
+	if req == nil {
+		return
+	}
+	if req.Method != "GET" {
+		t.Errorf("Got wrong method %s instead of GET.", req.Method)
+	}
+	expectedUrl := fmt.Sprintf("/_api/document/%s/%s", coll.name, "doc1")
+	if req.UrlPath != expectedUrl {
+		t.Errorf("Got wrong URL path %s instead of %s",
+			req.UrlPath, expectedUrl)
+	}
+
+	// Respond with a 200:
+	if x, ok := req.Result.(**UserDocument); ok {
+		*x = &UserDocument{}
+		**x = newDoc
+	}
+
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{StatusCode: 200},
+		Err:  nil,
+	}
+
+	// No more requests coming:
+	next(ctx, t, requests, false)
+}
+
+func TestCreateDocumentGoneButCreatedFail(t *testing.T) {
+	test := simpleTest{
+		SimpleConfig: config,
+		reportDir:    ".",
+		log:          log,
+		collections:  make(map[string]*collection),
+	}
+	mockClient := util.NewMockClient(t, createDocumentGoneButCreatedBehaviour)
+	test.client = mockClient
+	test.listener = util.MockListener{}
+	doc := UserDocument{
+		Key:   "doc1",
+		Value: 12,
+		Name:  "hanswurst",
+		Odd:   true,
+	}
+	_, err := test.createDocument(coll, doc, "doc1")
+	if err == nil {
+		t.Errorf("Expected to get an error, but got none.")
 	}
 	mockClient.Shutdown()
 }

--- a/tests/simple/simple_query.go
+++ b/tests/simple/simple_query.go
@@ -54,7 +54,6 @@ func (t *simpleTest) queryDocuments(c *collection) error {
 
 		createReqTime = time.Now()
 
-		// 410 remains until resolution of APM-185
 		createResp, err = t.client.Post(
 			"/_api/cursor", nil, nil, queryReq, "", &cursorResp, []int{0, 1, 201, 410, 500, 503},
 			[]int{200, 202, 307, 400, 404, 409}, operationTimeout, 1)
@@ -111,7 +110,7 @@ func (t *simpleTest) queryDocuments(c *collection) error {
 
 		// Fetch next results
 		getResp, err := t.client.Put(
-			"/_api/cursor/"+cursorResp.ID, nil, nil, nil, "", &cursorResp, []int{0, 1, 200, 404, 500, 503},
+			"/_api/cursor/"+cursorResp.ID, nil, nil, nil, "", &cursorResp, []int{0, 1, 200, 404, 410, 500, 503},
 			[]int{201, 202, 400, 409, 307}, operationTimeout, 1)
 		t.log.Infof("... got http %d - arangodb %d via %s",
 			getResp[0].StatusCode, getResp[0].Error_.ErrorNum, getResp[0].CoordinatorURL)

--- a/tests/simple/simple_query_update.go
+++ b/tests/simple/simple_query_update.go
@@ -35,7 +35,7 @@ func (t *simpleTest) queryUpdateDocuments(c *collection, key string) (string, er
 		resultDocument := &UserDocument{}
 		cursorResp.Result = []interface{}{resultDocument}
 		resp, err := t.client.Post(
-			"/_api/cursor", nil, nil, queryReq, "", &cursorResp, []int{0, 1, 201, 409, 500, 503},
+			"/_api/cursor", nil, nil, queryReq, "", &cursorResp, []int{0, 1, 201, 409, 410, 500, 503},
 			[]int{200, 202, 400, 404, 307}, operationTimeout, 1)
 		t.log.Infof("... got http %d - arangodb %d via %s",
 			resp[0].StatusCode, resp[0].Error_.ErrorNum, resp[0].CoordinatorURL)
@@ -114,7 +114,7 @@ func (t *simpleTest) queryUpdateDocumentsLongRunning(c *collection, key string) 
 		resultDocument := &UserDocument{}
 		cursorResp.Result = []interface{}{resultDocument}
 		resp, err := t.client.Post(
-			"/_api/cursor", nil, nil, queryReq, "", &cursorResp, []int{0, 1, 201, 409, 500, 503},
+			"/_api/cursor", nil, nil, queryReq, "", &cursorResp, []int{0, 1, 201, 409, 410, 500, 503},
 			[]int{200, 202, 400, 404, 307}, operationTimeout, 1)
 		t.log.Infof("... got http %d - arangodb %d via %s",
 			resp[0].StatusCode, resp[0].Error_.ErrorNum, resp[0].CoordinatorURL)

--- a/tests/simple/simple_remove.go
+++ b/tests/simple/simple_remove.go
@@ -23,6 +23,7 @@ func (t *simpleTest) removeExistingDocument(collectionName string, key, rev stri
 	backoff := time.Millisecond * 250
 	i := 0
 
+	mustExist := true
 	for {
 
 		i++
@@ -34,7 +35,7 @@ func (t *simpleTest) removeExistingDocument(collectionName string, key, rev stri
 		success := false
 		t.log.Infof("Removing (%d) existing document '%s' (%s) from '%s'...", i, key, ifMatchStatus, collectionName)
 		resp, err := t.client.Delete(
-			url, q, hdr, []int{0, 1, 200, 201, 202, 404, 409, 503}, []int{400, 412, 307}, operationTimeout, 1)
+			url, q, hdr, []int{0, 1, 200, 201, 202, 404, 409, 410, 503}, []int{400, 412, 307}, operationTimeout, 1)
 		t.log.Infof("... got http %d - arangodb %d via %s",
 			resp[0].StatusCode, resp[0].Error_.ErrorNum, resp[0].CoordinatorURL)
 
@@ -42,17 +43,21 @@ func (t *simpleTest) removeExistingDocument(collectionName string, key, rev stri
 			if resp[0].StatusCode == 0 || resp[0].StatusCode == 409 || resp[0].StatusCode == 503 {
 				// 0, 409 and 503 -> check if accidentally successful
 				checkRetry = true
+				mustExist = false
+			} else if resp[0].StatusCode == 410 {
+				// 410 -> document must have NOT been deleted. re-check this and retry.
+				checkRetry = true
 			} else if resp[0].StatusCode == 404 {
-				if i == 1 {
+				if mustExist {
 					// Not enough attempts, this is a failure
 					t.deleteExistingCounter.failed++
 					t.reportFailure(
 						test.NewFailure(
-							"Failed to delete existing document '%s' (%s) in collection '%s': got 404 after only 1 attempt",
+							"Failed to delete existing document '%s' (%s) in collection '%s': got 404 after only 1 attempt, or after receiving 410(GONE) for previous attempts.",
 							key, ifMatchStatus, collectionName))
 					return maskAny(
 						fmt.Errorf(
-							"Failed to delete existing document '%s' (%s) in collection '%s': got 404 after only 1 attempt",
+							"Failed to delete existing document '%s' (%s) in collection '%s': got 404 after only 1 attempt, or after receiving 410(GONE) for previous attempts.",
 							key, ifMatchStatus, collectionName))
 				} else {
 					// Potentially, an earlier try timed out but the document was
@@ -128,7 +133,7 @@ func (t *simpleTest) removeExistingDocumentWrongRevision(collectionName string, 
 
 		t.log.Infof("Removing existing document '%s' wrong revision from '%s'...", key, collectionName)
 		resp, err := t.client.Delete(
-			url, q, hdr, []int{0, 1, 412, 503}, []int{200, 201, 202, 400, 404, 307}, operationTimeout, 1)
+			url, q, hdr, []int{0, 1, 410, 412, 503}, []int{200, 201, 202, 400, 404, 307}, operationTimeout, 1)
 		t.log.Infof("... got http %d - arangodb %d via %s",
 			resp[0].StatusCode, resp[0].Error_.ErrorNum, resp[0].CoordinatorURL)
 
@@ -185,7 +190,7 @@ func (t *simpleTest) removeNonExistingDocument(collectionName string, key string
 
 		t.log.Infof("Removing (%d) non-existing document '%s' from '%s'...", i, key, collectionName)
 		resp, err := t.client.Delete(
-			url, q, nil, []int{0, 1, 404, 503}, []int{200, 201, 202, 400, 412, 307}, operationTimeout, 1)
+			url, q, nil, []int{0, 1, 404, 410, 503}, []int{200, 201, 202, 400, 412, 307}, operationTimeout, 1)
 		t.log.Infof("... got http %d - arangodb %d via %s",
 			resp[0].StatusCode, resp[0].Error_.ErrorNum, resp[0].CoordinatorURL)
 

--- a/tests/simple/simple_replace_test.go
+++ b/tests/simple/simple_replace_test.go
@@ -610,92 +610,94 @@ func TestReplaceExistingDocumentReadNotFound(t *testing.T) {
 	mockClient.Shutdown()
 }
 
-// func replaceExistingDocumentGoneButWrittenFailBehaviour(
-// 	ctx context.Context, t *testing.T,
-// 	requests chan *util.MockRequest, responses chan *util.MockResponse) {
+func replaceExistingDocumentGoneButWrittenFailBehaviour(
+	ctx context.Context, t *testing.T,
+	requests chan *util.MockRequest, responses chan *util.MockResponse) {
 
-// 	// Get a normal POST request (as preparation)
-// 	req := next(ctx, t, requests, true)
-// 	if req == nil {
-// 		return
-// 	}
-// 	if req.Method != "POST" {
-// 		t.Errorf("Got wrong method %s instead of POST.", req.Method)
-// 	}
-// 	path := "/_api/document/" + coll.name
-// 	if req.UrlPath != path {
-// 		t.Errorf("Got wrong URL path %s instead of %s", req.UrlPath, path)
-// 	}
+	// Get a normal POST request (as preparation)
+	req := next(ctx, t, requests, true)
+	if req == nil {
+		return
+	}
+	if req.Method != "POST" {
+		t.Errorf("Got wrong method %s instead of POST.", req.Method)
+	}
+	path := "/_api/document/" + coll.name
+	if req.UrlPath != path {
+		t.Errorf("Got wrong URL path %s instead of %s", req.UrlPath, path)
+	}
 
-// 	// Answer with a normal good response:
-// 	responses <- &util.MockResponse{
-// 		Resp: util.ArangoResponse{StatusCode: 200, Rev: "abcd1234"},
-// 		Err:  nil,
-// 	}
+	// Answer with a normal good response:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{StatusCode: 200, Rev: "abcd1234"},
+		Err:  nil,
+	}
 
-// 	// Get a normal PUT request:
-// 	req = next(ctx, t, requests, true)
-// 	if req == nil {
-// 		return
-// 	}
-// 	if req.Method != "PUT" {
-// 		t.Errorf("Got wrong method %s instead of PUT.", req.Method)
-// 	}
-// 	newDocument := req.Input.(UserDocument)
+	// Get a normal PUT request:
+	req = next(ctx, t, requests, true)
+	if req == nil {
+		return
+	}
+	if req.Method != "PUT" {
+		t.Errorf("Got wrong method %s instead of PUT.", req.Method)
+	}
+	newDocument := req.Input.(UserDocument)
 
-// 	// respond with 410:
-// 	responses <- &util.MockResponse{
-// 		Resp: util.ArangoResponse{StatusCode: 410},
-// 		Err:  nil,
-// 	}
+	// respond with 410:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{StatusCode: 410},
+		Err:  nil,
+	}
 
-// 	// Get a read requests:
-// 	req = next(ctx, t, requests, true)
-// 	if req == nil {
-// 		return
-// 	}
-// 	if req.Method != "GET" {
-// 		t.Errorf("Got wrong method %s instead of GET.", req.Method)
-// 	}
+	// Get a read requests:
+	req = next(ctx, t, requests, true)
+	if req == nil {
+		return
+	}
+	if req.Method != "GET" {
+		t.Errorf("Got wrong method %s instead of GET.", req.Method)
+	}
 
-// 	*req.Result.(**interface{}) = &newDocument
+	if x, ok := req.Result.(**UserDocument); ok {
+		*x = &newDocument
+	}
 
-// 	// Return new document:
-// 	responses <- &util.MockResponse{
-// 		Resp: util.ArangoResponse{StatusCode: 200},
-// 		Err:  nil,
-// 	}
+	// Return new document:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{StatusCode: 200},
+		Err:  nil,
+	}
 
-// 	// No more requests coming:
-// 	next(ctx, t, requests, false)
-// }
+	// No more requests coming:
+	next(ctx, t, requests, false)
+}
 
-// func TestReplaceExistingDocumentGoneButWritten(t *testing.T) {
-// 	test := simpleTest{
-// 		SimpleConfig: config,
-// 		reportDir:    ".",
-// 		log:          log,
-// 		collections:  make(map[string]*collection),
-// 	}
-// 	mockClient := util.NewMockClient(t, replaceExistingDocumentGoneButWrittenFailBehaviour)
-// 	test.client = mockClient
-// 	test.listener = util.MockListener{}
-// 	doc := UserDocument{
-// 		Key:   "doc1",
-// 		Value: 12,
-// 		Name:  "hanswurst",
-// 		Odd:   true,
-// 	}
-// 	rev, err := test.createDocument(coll, doc, "doc1")
-// 	if rev == "" || err != nil {
-// 		t.Errorf("Unexpected result from createDocument: %v, err: %v", rev, err)
-// 	}
-// 	_, err = test.replaceExistingDocument(coll, "doc1", rev)
-// 	if err == nil {
-// 		t.Error("Unexpected result from replaceExistingDocument. Exprected an error.")
-// 	}
-// 	mockClient.Shutdown()
-// }
+func TestReplaceExistingDocumentGoneButWritten(t *testing.T) {
+	test := simpleTest{
+		SimpleConfig: config,
+		reportDir:    ".",
+		log:          log,
+		collections:  make(map[string]*collection),
+	}
+	mockClient := util.NewMockClient(t, replaceExistingDocumentGoneButWrittenFailBehaviour)
+	test.client = mockClient
+	test.listener = util.MockListener{}
+	doc := UserDocument{
+		Key:   "doc1",
+		Value: 12,
+		Name:  "hanswurst",
+		Odd:   true,
+	}
+	rev, err := test.createDocument(coll, doc, "doc1")
+	if rev == "" || err != nil {
+		t.Errorf("Unexpected result from createDocument: %v, err: %v", rev, err)
+	}
+	_, err = test.replaceExistingDocument(coll, "doc1", rev)
+	if err == nil {
+		t.Error("Unexpected result from replaceExistingDocument. Exprected an error.")
+	}
+	mockClient.Shutdown()
+}
 
 func replaceExistingDocumentReadUnexpected(
 	ctx context.Context, t *testing.T,

--- a/tests/simple/simple_update_test.go
+++ b/tests/simple/simple_update_test.go
@@ -60,6 +60,45 @@ func updateExistingDocumentOk(
 		t.Errorf("Got wrong method %s instead of PATCH.", req.Method)
 	}
 
+	// Respond immediately with a 410:
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{StatusCode: 410},
+		Err:  nil,
+	}
+
+	// Now expect a GET request to see if the document is there, answer
+	// with yes:
+	req = next(ctx, t, requests, true)
+	if req == nil {
+		return
+	}
+	if req.Method != "GET" {
+		t.Errorf("Got wrong method %s instead of GET.", req.Method)
+	}
+	path = "/_api/document/" + coll.name + "/doc1"
+	if req.UrlPath != path {
+		t.Errorf("Got wrong URL path %s instead of %s", req.UrlPath, path)
+	}
+
+	// Respond with found, but original version:
+	if x, ok := req.Result.(**UserDocument); ok {
+		*x = &UserDocument{}
+		**x = coll.existingDocs["doc1"]
+	}
+	responses <- &util.MockResponse{
+		Resp: util.ArangoResponse{StatusCode: 200, Rev: "abc1235"},
+		Err:  nil,
+	}
+
+	// Get another document request:
+	req = next(ctx, t, requests, true)
+	if req == nil {
+		return
+	}
+	if req.Method != "PATCH" {
+		t.Errorf("Got wrong method %s instead of PATCH.", req.Method)
+	}
+
 	// Respond immediately with a 503:
 	responses <- &util.MockResponse{
 		Resp: util.ArangoResponse{StatusCode: 503},


### PR DESCRIPTION
This change will make tests retry when cursor post/put methods return 410, instead of failing immediately. 